### PR TITLE
Add HoundCI configuration file

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,4 @@
+scss:
+  config_file: .scss-lint.yml
+ruby:
+  config_file: .rubocop.yml


### PR DESCRIPTION
Why?
By default, HoundCI uses it own defined rules to check for style
violations, I want it to use the rubocop and scss-lint settings instead.

How?
Add .hound.yml file to the project root.
Edit the file, setting the it to use the rubocop.yml and scss-lint.yml
file as rule guide.