### PR TITLE
Add the circle.yml file to the project root

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,7 @@
+machine:
+  ruby:
+    version: 2.1.6
+
+dependencies:
+  pre:
+    - gem install bundler --pre


### PR DESCRIPTION
Why?
CircleCI could not build unless I add the circle.yml

How?
Add file 'circle.yml'
specify the ruby version and dependencies

Completing Add the cirlce.yml feature:
https://www.pivotaltracker.com/story/show/109519772
[finished #109519772]